### PR TITLE
Code quality fix - The diamond operator ("<>") should be used.

### DIFF
--- a/src/main/java/com/github/rjeschke/txtmark/Configuration.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Configuration.java
@@ -129,7 +129,7 @@ public class Configuration
 
         private SpanEmitter specialLinkEmitter = null;
 
-        private final List<Plugin> plugins = new ArrayList<Plugin>();
+        private final List<Plugin> plugins = new ArrayList<>();
 
         /**
          * Constructor.

--- a/src/main/java/com/github/rjeschke/txtmark/Emitter.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Emitter.java
@@ -32,7 +32,7 @@ import org.markdown4j.Plugin;
 class Emitter
 {
     /** Link references. */
-    private final HashMap<String, LinkRef> linkRefs = new HashMap<String, LinkRef>();
+    private final HashMap<String, LinkRef> linkRefs = new HashMap<>();
     /** The configuration. */
     private final Configuration config;
     /** Extension flag. */
@@ -40,7 +40,7 @@ class Emitter
     /** Newline flag. */
     public boolean convertNewline2Br = false;
     /** Plugins references **/
-	private Map<String, Plugin> plugins = new HashMap<String, Plugin>();
+	private Map<String, Plugin> plugins = new HashMap<>();
     
     /** Constructor. */
     public Emitter(final Configuration config)
@@ -987,7 +987,7 @@ class Emitter
         Line line = lines;
         if(this.config.codeBlockEmitter != null)
         {
-            final ArrayList<String> list = new ArrayList<String>();
+            final ArrayList<String> list = new ArrayList<>();
             while(line != null)
             {
                 if(line.isEmpty)
@@ -1056,9 +1056,9 @@ class Emitter
 		}
 		
 		if(params == null) {
-			params = new HashMap<String, String>();
+			params = new HashMap<>();
 		}
-        final ArrayList<String> list = new ArrayList<String>();
+        final ArrayList<String> list = new ArrayList<>();
         while(line != null)
         {
             if(line.isEmpty)
@@ -1075,7 +1075,7 @@ class Emitter
     }
     
 	protected Map<String, String> parsePluginParams(String s) {
-		Map<String, String> params = new HashMap<String, String>();
+		Map<String, String> params = new HashMap<>();
 	     Pattern p = Pattern.compile("(\\w+)=\"*((?<=\")[^\"]+(?=\")|([^\\s]+))\"*");
 
 	     Matcher m = p.matcher(s);

--- a/src/main/java/com/github/rjeschke/txtmark/HTML.java
+++ b/src/main/java/com/github/rjeschke/txtmark/HTML.java
@@ -130,17 +130,17 @@ class HTML
     };
     
     /** Character to entity encoding map. */
-    private final static HashMap<Character, String> encodeMap = new HashMap<Character, String>();
+    private final static HashMap<Character, String> encodeMap = new HashMap<>();
     /** Entity to character decoding map. */
-    private final static HashMap<String, Character> decodeMap = new HashMap<String, Character>();
+    private final static HashMap<String, Character> decodeMap = new HashMap<>();
     /** Set of valid HTML tags. */
-    private final static HashSet<String> HTML_ELEMENTS = new HashSet<String>();
+    private final static HashSet<String> HTML_ELEMENTS = new HashSet<>();
     /** Set of unsafe HTML tags. */
-    private final static HashSet<String> HTML_UNSAFE = new HashSet<String>();
+    private final static HashSet<String> HTML_UNSAFE = new HashSet<>();
     /** Set of HTML block level tags. */
-    private final static HashSet<String> HTML_BLOCK_ELEMENTS = new HashSet<String>();
+    private final static HashSet<String> HTML_BLOCK_ELEMENTS = new HashSet<>();
     /** Set of valid markdown link prefixes. */
-    private final static HashSet<String> LINK_PREFIX = new HashSet<String>();
+    private final static HashSet<String> LINK_PREFIX = new HashSet<>();
 
     static
     {

--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -463,7 +463,7 @@ class Line
      */
     private boolean checkHTML()
     {
-        final LinkedList<String> tags = new LinkedList<String>();
+        final LinkedList<String> tags = new LinkedList<>();
         final StringBuilder temp = new StringBuilder();
         int pos = this.leading;
         if(this.value.charAt(this.leading + 1) == '!')

--- a/src/main/java/org/markdown4j/HtmlAttributes.java
+++ b/src/main/java/org/markdown4j/HtmlAttributes.java
@@ -5,13 +5,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class HtmlAttributes {
-  private Map<String, Map<String, String>> attsByTag = new HashMap<String, Map<String, String>>();
+  private Map<String, Map<String, String>> attsByTag = new HashMap<>();
   
   
   public HtmlAttributes put(String tagName, String attName, String attValue) {
 	  Map<String, String> atts = attsByTag.get(tagName);
 	  if(atts == null) {
-		  atts = new LinkedHashMap<String, String>();
+		  atts = new LinkedHashMap<>();
 		  attsByTag.put(tagName, atts);
 	  }
 	  atts.put(attName, attValue);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - The diamond operator ("<>") should be used. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293

Please let me know if you have any questions.

Faisal Hameed
