### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/org/markdown4j/IncludePlugin.java
+++ b/src/main/java/org/markdown4j/IncludePlugin.java
@@ -10,6 +10,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -96,10 +97,10 @@ public class IncludePlugin extends Plugin {
 
     public static String getCharsetFromContent(URL url) throws IOException {
         InputStream stream = url.openStream();
-        byte chunk[] = new byte[2048];
+        byte[] chunk = new byte[2048];
         int bytesRead = stream.read(chunk);
         if (bytesRead > 0) {
-            String startContent = new String(chunk);
+            String startContent = new String(chunk, StandardCharsets.UTF_8);
             String pattern = "\\<meta\\s*http-equiv=[\\\"\\']content-type[\\\"\\']\\s*content\\s*=\\s*[\"']text/html\\s*;\\s*charset=([a-z\\d\\-]*)[\\\"\\'\\>]";
             Matcher matcher = Pattern.compile(pattern,  Pattern.CASE_INSENSITIVE).matcher(startContent);
             if (matcher.find()) {

--- a/src/main/java/org/markdown4j/WebSequencePlugin.java
+++ b/src/main/java/org/markdown4j/WebSequencePlugin.java
@@ -7,6 +7,7 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -53,7 +54,7 @@ public class WebSequencePlugin extends Plugin {
             URL url = new URL("http://www.websequencediagrams.com");
             URLConnection conn = url.openConnection();
             conn.setDoOutput(true);
-            OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream());
+            OutputStreamWriter writer = new OutputStreamWriter(conn.getOutputStream(), StandardCharsets.UTF_8);
             
             //write parameters
             writer.write(data);
@@ -61,7 +62,7 @@ public class WebSequencePlugin extends Plugin {
             
             // Get the response
             StringBuilder answer = new StringBuilder();
-            BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream()));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8));
             String line;
             while ((line = reader.readLine()) != null) {
                 answer.append(line);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 - Classes and methods that rely on the default system encoding should not be used.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1943
https://dev.eclipse.org/sonar/rules/show/squid:S1197

Please let me know if you have any questions.

Faisal Hameed
