### PR TITLE
General code quality fix-3

### DIFF
--- a/src/main/java/com/github/rjeschke/txtmark/Line.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Line.java
@@ -523,7 +523,7 @@ class Line
                                 tags.addLast(tag);
                             }
                         }
-                        if(tags.size() == 0)
+                        if(tags.isEmpty())
                         {
                             this.xmlEndLine = line;
                             break;
@@ -536,7 +536,7 @@ class Line
                     }
                 }
             }
-            return tags.size() == 0;
+            return tags.isEmpty();
         }
         return false;
     }

--- a/src/main/java/com/github/rjeschke/txtmark/Processor.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Processor.java
@@ -770,11 +770,9 @@ public class Processor
             // To make compiler happy: add != null checks
             if ( isLinkRef && id != null && link != null )
             {
-                if ( id.toLowerCase()
-                       .equals( "$profile$" ) )
+                if ( id.equalsIgnoreCase( "$profile$" ) )
                 {
-                    this.emitter.useExtensions = this.useExtensions = link.toLowerCase()
-                                                                          .equals( "extended" );
+                    this.emitter.useExtensions = this.useExtensions = link.equalsIgnoreCase( "extended" );
                     lastLinkRef = null;
                 }
                 else


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1155 - Collection.isEmpty() should be used to test for emptiness. 
squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1157

Please let me know if you have any questions.

Faisal Hameed
