### PR TITLE
General code quality fix-4

### DIFF
--- a/src/main/java/com/github/rjeschke/txtmark/Emitter.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Emitter.java
@@ -865,7 +865,7 @@ class Emitter
                         return MarkToken.X_COPY;
                     if(c1 == 'R' && c2 == ')')
                         return MarkToken.X_REG;
-                    if(c1 == 'T' & c2 == 'M' & c3 == ')')
+                    if(c1 == 'T' && c2 == 'M' && c3 == ')')
                         return MarkToken.X_TRADE;
                     break;
                 case '"':

--- a/src/main/java/com/github/rjeschke/txtmark/Utils.java
+++ b/src/main/java/com/github/rjeschke/txtmark/Utils.java
@@ -23,7 +23,7 @@ package com.github.rjeschke.txtmark;
 class Utils
 {
     /** Random number generator value. */
-    private static int RND = (int)System.nanoTime();
+    private static int rndValue = (int)System.nanoTime();
 
     /**
      * LCG random number generator.
@@ -32,7 +32,7 @@ class Utils
      */
     public final static int rnd()
     {
-        return (RND = RND * 1664525 + 1013904223) >>> 22;
+        return (rndValue = rndValue * 1664525 + 1013904223) >>> 22;
     }
 
     /**

--- a/src/main/java/org/markdown4j/WebSequencePlugin.java
+++ b/src/main/java/org/markdown4j/WebSequencePlugin.java
@@ -75,8 +75,7 @@ public class WebSequencePlugin extends Plugin {
             int end = json.indexOf( "\"", start );
             
             if(start != -1 && end != -1) {
-                String surl =  "http://www.websequencediagrams.com/" + json.substring(start, end) ;	            	            
-                return surl;            	
+                return "http://www.websequencediagrams.com/" + json.substring(start, end) ;	            	                        	
             }
             return null;
             	            


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown. 
squid:S3008 -  Static non-final field names should comply with a naming convention.
squid:S2178 - Short-circuit logic should be used in boolean contexts.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S3008
https://dev.eclipse.org/sonar/rules/show/squid:S2178

Please let me know if you have any questions.

Faisal Hameed
